### PR TITLE
Improve robustness of dependency check

### DIFF
--- a/tests/check_no_dependencies.sh
+++ b/tests/check_no_dependencies.sh
@@ -1,5 +1,11 @@
 #!/bin/bash
-if [[ $(poetry show --no-dev) ]]; then
+set -o errexit
+set -o nounset
+set -o pipefail
+
+main_dependencies=$(poetry show --only main)
+
+if [[ "$main_dependencies" ]]; then
     exit 1
 else
     exit 0


### PR DESCRIPTION
Changes for the user: none.

Changes for developers:

- Errors in the scripts are now detected (with an appropriate exit code) instead of being ignored. This could be an issue, for example, if we made a typo in an argument passed to `poetry show`.
- `--no-dev` is replaced by `--only main` since the former is deprecated. This avoids a warning, and future breakage.